### PR TITLE
Add possibility to set time-out and enable fetching invalid certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 lsp
 psalm.xml
 composer.phar
+vendor

--- a/CheckSSL.php
+++ b/CheckSSL.php
@@ -150,6 +150,8 @@ class CheckSSL
         return stream_context_create(
             [
                 'ssl' => [
+                    'verify_peer' => false,
+                    'verify_peer_name' => false,
                     'capture_peer_cert' => true
                 ]
             ]

--- a/CheckSSL.php
+++ b/CheckSSL.php
@@ -99,6 +99,11 @@ class CheckSSL
         return $this->getResults();
     }
 
+    public function getTimeout(): float 
+    {
+        return $this->timeOut;
+    }
+
     /**
      * @param resource|false $siteStream
      * @return array

--- a/CheckSSL.php
+++ b/CheckSSL.php
@@ -21,6 +21,7 @@ class CheckSSL
     protected string $dateFormat;
     protected string $formatString;
     protected ?string $timeZone;
+    protected float $timeOut;
 
     /**
      * CheckSSL constructor.
@@ -28,14 +29,16 @@ class CheckSSL
      * @param string $dateFormat
      * @param string $formatString
      * @param string|null $timeZone
+     * @param float $timeOut
      * @throws Exception
      */
-    public function __construct(array $url = [],string $dateFormat = 'U',string $formatString = 'Y-m-d\TH:i:s\Z',?string $timeZone = null)
+    public function __construct(array $url = [],string $dateFormat = 'U',string $formatString = 'Y-m-d\TH:i:s\Z',?string $timeZone = null,float $timeOut = 30)
     {
         ! empty($url) ? $this->add($url) : $this->urls = $url;
         $this->dateFormat = $dateFormat;
         $this->timeZone = $timeZone;
         $this->formatString = $formatString;
+        $this->timeOut = $timeOut;
         $this->result = [];
     }
 
@@ -168,8 +171,11 @@ class CheckSSL
             $messageError = 'error to get certificate';
             $cert = @stream_socket_client(
                 'ssl://' . $url. ':443',
-                $errno, $messageError, 30,
-                STREAM_CLIENT_CONNECT, $this->getStreamContext()
+                $errno, 
+                $messageError, 
+                $this->timeOut,
+                STREAM_CLIENT_CONNECT, 
+                $this->getStreamContext()
             );
         } catch (\Exception $exception)  {
             throw new RuntimeException($exception->getMessage());

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ print_r($example3);
 ```
 
 
-#### Custom output format
+#### Custom output format / custom timeout
 
 ``` php
 <?php
@@ -134,8 +134,9 @@ $data = [ 'https://symfony.com', 'https://getlaminas.org'];
 $dateFormat = 'U';
 $formatString = 'd-m-Y H:i:s';
 $timeZone = 'America/Sao_Paulo';
+$timeOut = 30
 
-$checkSLL = new CheckSSL($data, $dateFormat, $formatString, $timeZone);
+$checkSLL = new CheckSSL($data, $dateFormat, $formatString, $timeZone, $timeOut);
 
 print_r($checkSLL->check());
 ```

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
 
     "require": {
         "php":"7.4.*",
-        "ext-openssl": "*",
-        "ext-curl": "*"
+        "ext-openssl": "*"
     },
     "autoload": {
         "psr-4": { "JrBarros\\": "" }

--- a/tests/CheckSSLTest.php
+++ b/tests/CheckSSLTest.php
@@ -58,6 +58,13 @@ final class CheckSSLTest extends TestCase
         );
     }
 
+    public function testCustomTimeout() {
+
+        $checkSLL = new CheckSSL([], '', '', '', 60.0);
+
+        $this->assertEquals(60.0, $checkSLL->getTimeout());
+    }
+
     public function test() {
 
         $this->expectException(TypeError::class);


### PR DESCRIPTION
This PR adds some small improvements

##### 1. Possibility to add time-out option

It's good to have this configurable in case users wants to increase/decrease the default timeout.

##### 2. Enables fetching invalid certificates

The current implementation returns `NULL` when a certificate is invalid. This is not really helpful as you don't know what caused the error. It also means that `is_valid` can never be false since fetching invalid certificates is impossible. 😅 This PR disables validating certificates altogether.

##### 3. Remove `ext-curl` from composer dependencies.

It doesn't appear to be used.